### PR TITLE
isExpanded() would always retun true if called before layout.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -630,7 +630,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     }
 
     private boolean expandPane(View pane, int initialVelocity) {
-        if (mFirstLayout || smoothSlideTo(0.f, initialVelocity)) {
+        if (!mPanelHidden && (mFirstLayout || smoothSlideTo(0.f, initialVelocity))) {
             mPreservedExpandedState = true;
             return true;
         }
@@ -638,7 +638,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     }
 
     private boolean collapsePane(View pane, int initialVelocity) {
-        if (mFirstLayout || smoothSlideTo(mCollapsedOffset, initialVelocity)) {
+        if (!mPanelHidden && (mFirstLayout || smoothSlideTo(mCollapsedOffset, initialVelocity))) {
             mPreservedExpandedState = false;
             return true;
         }


### PR DESCRIPTION
After restoreInstanceState, isExpanded() currently always returns true if the initial layout hasn't been completed yet, requiring you to keep track of the state in the activity to e.g. set the visible state of the actionbar upon activity creation.
