### PR TITLE
Added support for a horizontally scrollable drag view

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -558,7 +558,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                         return super.onInterceptTouchEvent(ev);
                     }
                     // Intercept the touch if the drag view has any vertical scroll.
-	            // onTouchEvent will determine if the view should drag vertically.
+                    // onTouchEvent will determine if the view should drag vertically.
                     else if (ady > mScrollTouchSlop) {
                         interceptTap = mDragViewHit;
                     }


### PR DESCRIPTION
If mIsUsingDragViewTouchEvents is set to true, a drag view can scroll horizontally and use it's own click listener.  Default is set to false.
