### PR TITLE
isExpanded() would always retun true if called before layout.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -611,7 +611,8 @@ public class SlidingUpPanelLayout extends ViewGroup {
      * @return true if sliding panels are completely expanded
      */
     public boolean isExpanded() {
-        return mCanSlide && mSlideOffset == 0;
+        return mFirstLayout && mPreservedExpandedState
+                || !mFirstLayout && mCanSlide && mSlideOffset == 0;
     }
 
     /**


### PR DESCRIPTION
Fixed version of https://github.com/umano/AndroidSlidingUpPanel/pull/27
