### PR TITLE
Fix: when the panel height is changed the layout is not updated with that value.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -216,6 +216,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
      */
     public void setPanelHeight(int val) {
         mPanelHeight = val;
+        requestLayout();
     }
 
     /**


### PR DESCRIPTION
If for some reason you need to change the height at runtime the layout is not updated accordingly.

Also, is there some reason that the panel height is not set as default with the height of the drag view?
