### PR TITLE
Fixed issue where a fling on a view which was not the drag view could co...

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -620,7 +620,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                     }
                 }
 
-                if (ady > dragSlop && adx > ady) {
+                if ((ady > dragSlop && adx > ady) || !isDragViewUnder((int) x, (int) y)) {
                     mDragHelper.cancel();
                     mIsUnableToDrag = true;
                     return false;


### PR DESCRIPTION
...llapse the sliding panel (for example, if there was a list under the drag view and the user tries to scroll up on the list view fast enough it will trigger a collapse).
