### PR TITLE
Add layout_gravity option

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -234,7 +234,11 @@ public class SlidingUpPanelLayout extends ViewGroup {
             TypedArray defAttrs = context.obtainStyledAttributes(attrs, DEFAULT_ATTRS);
 
             if (defAttrs != null) {
-                mIsSlidingUp = defAttrs.getInt(0, Gravity.BOTTOM) == Gravity.BOTTOM;
+                int gravity = defAttrs.getInt(0, Gravity.NO_GRAVITY);
+                if (gravity != Gravity.TOP && gravity != Gravity.BOTTOM) {
+                    throw new IllegalArgumentException("layout_gravity must be set to either top or bottom");
+                }
+                mIsSlidingUp = gravity == Gravity.BOTTOM;
             }
 
             defAttrs.recycle();


### PR DESCRIPTION
When layout has no `android:layout_gravity` attribute or set it to `"bottom"`, it is exactly same with past AndroidSlidingUpPanel d38270f531d77d8f2bffe3b8baf1d08b5acdb83a.
If `android:layout_gravity` set to `"top"`, the slideable view goes to the top of layout and we can drag it down to expand.
