### PR TITLE
Fixes incorrect amount from getSlidingTop()

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -735,7 +735,9 @@ public class SlidingUpPanelLayout extends ViewGroup {
 
     private int getSlidingTop() {
         if (mSlideableView != null) {
-            return getMeasuredHeight() - getPaddingBottom() - mSlideableView.getMeasuredHeight();
+            return mIsSlidingUp
+                ? getMeasuredHeight() - getPaddingBottom() - mSlideableView.getMeasuredHeight()
+                : getMeasuredHeight() - getPaddingBottom() - (mSlideableView.getMeasuredHeight() * 2);
         }
 
         return getMeasuredHeight() - getPaddingBottom();


### PR DESCRIPTION
This fixes a bug that caused ithe sliding panel to be incorrectly
placed in the middle of the screen when sliding from the top.

Fixes issue #137
