### PR TITLE
Prevent the custom View to be drawn in the UI editor

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -255,6 +255,11 @@ public class SlidingUpPanelLayout extends ViewGroup {
 
     public SlidingUpPanelLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        
+        if(isInEditMode()) {
+            return;
+        }
+        
         if (attrs != null) {
             TypedArray defAttrs = context.obtainStyledAttributes(attrs, DEFAULT_ATTRS);
 


### PR DESCRIPTION
Usually the UI editor in Eclipse or IntelliJ will throw errors, if they are trying to render complex custom Views. These two lines will prevent that.
