### PR TITLE
Added anchorPoint and initialState attrs (and update source acording to ...

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -3,12 +3,18 @@
 
     <declare-styleable name="SlidingUpPanelLayout">
         <attr name="panelHeight" format="dimension" />
+        <attr name="anchorPoint" format="float"/>
         <attr name="shadowHeight" format="dimension" />
         <attr name="paralaxOffset" format="dimension" />
         <attr name="fadeColor" format="color" />
         <attr name="flingVelocity" format="integer" />
         <attr name="dragView" format="reference" />
         <attr name="overlay" format="boolean"/>
+        <attr name="initialState" format="enum">
+            <enum name="expanded" value="0" />
+            <enum name="collapsed" value="1" />
+            <enum name="anchored" value="2" />
+        </attr>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
...this new options)

I've added two new options that I think it could be useful:
- You could now set the anchor point in attrs. So in that way you don't have to clutter your Java code. Also you can use the method expandToAnchor().
- You could now set the initial state in which the panel will be shown (three options are posible: start collapsed, start anchored or start expanded).

Note:
I had to change several variables from final to non final because Android Studio was throwing errors about final variables not initialized!
