### PR TITLE
Allow tap interception to be configurable

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="flingVelocity" format="integer" />
         <attr name="dragView" format="reference" />
         <attr name="overlay" format="boolean"/>
+        <attr name="interceptTaps" format="boolean"/>
     </declare-styleable>
 
 </resources>

--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -122,6 +122,12 @@ public class SlidingUpPanelLayout extends ViewGroup {
     private View mDragView;
 
     /**
+     * If set to true, will intercept tap events on the drag view; otherwise, they will not be captured
+     * and will allow horizontal scroll in the drag view.
+     */
+    private boolean mInterceptTaps = true;
+
+    /**
      * If provided, the panel can be dragged by only this view. Otherwise, the entire panel can be
      * used for dragging.
      */
@@ -289,6 +295,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 mDragViewResId = ta.getResourceId(R.styleable.SlidingUpPanelLayout_dragView, -1);
 
                 mOverlayContent = ta.getBoolean(R.styleable.SlidingUpPanelLayout_overlay,DEFAULT_OVERLAY_FLAG);
+                mInterceptTaps = ta.getBoolean(R.styleable.SlidingUpPanelLayout_interceptTaps, true);
             }
 
             ta.recycle();
@@ -697,7 +704,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 mIsUnableToDrag = false;
                 mInitialMotionX = x;
                 mInitialMotionY = y;
-                if (isDragViewUnder((int) x, (int) y) && !mIsUsingDragViewTouchEvents) {
+                if (mInterceptTaps && isDragViewUnder((int) x, (int) y) && !mIsUsingDragViewTouchEvents) {
                     interceptTap = true;
                 }
                 break;


### PR DESCRIPTION
Allow tap interception to be configurable so that we can allow horizontal scrolling in the drag view