### PR TITLE
Removes targetSdkVersion="19" restriction

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -5,8 +5,7 @@
     android:versionName="1.0.0">
 
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="8" />
 
     <application />
 


### PR DESCRIPTION
This leaves it up for the project that is including this library to define what the `targetSdkVersion` will be.

```
[/Users/felipecsl/myproject/main/AndroidManifest.xml:5, /Users/felipecsl/myproject/build/exploded-aar/com.sothree.slidinguppanel/library/1.0.1/AndroidManifest.xml:3] Main manifest has <uses-sdk android:targetSdkVersion='18'> but library uses targetSdkVersion='19'
:myproject:processDefaultFlavorDebugManifest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':myproject:processDefaultFlavorDebugManifest'.
> Manifest merging failed. See console for more info.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
```
