### PR TITLE
Missing events on slower devices

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1111,18 +1111,18 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 if (mSlideOffset == 0) {
                     if (mSlideState != SlideState.EXPANDED) {
                         updateObscuredViewVisibility();
-                        dispatchOnPanelExpanded(mSlideableView);
                         mSlideState = SlideState.EXPANDED;
+                        dispatchOnPanelExpanded(mSlideableView);
                     }
                 } else if (mSlideOffset == (float)anchoredTop/(float)mSlideRange) {
                     if (mSlideState != SlideState.ANCHORED) {
                         updateObscuredViewVisibility();
-                        dispatchOnPanelAnchored(mSlideableView);
                         mSlideState = SlideState.ANCHORED;
+                        dispatchOnPanelAnchored(mSlideableView);
                     }
                 } else if (mSlideState != SlideState.COLLAPSED) {
-                    dispatchOnPanelCollapsed(mSlideableView);
                     mSlideState = SlideState.COLLAPSED;
+                    dispatchOnPanelCollapsed(mSlideableView);
                 }
             }
         }


### PR DESCRIPTION
Recompute slide offset from sliding view top when drag state becomes idle. Some slower devices were missing the final onPanelDragged events so the onPanelExpanded, onPanelAnchored & onPanelCollapsed events were not being fired.
