### PR TITLE
Expose ability to save and restore state.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1070,7 +1070,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     }
 
     @Override
-    protected Parcelable onSaveInstanceState() {
+    public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
 
         SavedState ss = new SavedState(superState);
@@ -1080,7 +1080,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     }
 
     @Override
-    protected void onRestoreInstanceState(Parcelable state) {
+    public void onRestoreInstanceState(Parcelable state) {
         SavedState ss = (SavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
         mSlideState = ss.mSlideState;


### PR DESCRIPTION
Use case for this is when you want to restore state due to something other than a configuration change. For example, I have different layouts for portrait vs. landscape and the sliding up panel is not used in the landscape layout. Therefore its state is not restored if I rotate to landscape and back to portrait. With this change, however, I can manually save the sliding up panel state on rotation to landscape and restore it when the user rotates back to portrait.
