### PR TITLE
Change android support library version to 19.1.+

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -24,6 +24,6 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-v4:+'
+  compile 'com.android.support:support-v4:19.1.+'
   compile project(':library')
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   compile 'com.android.support:support-v4:+'
-  compile 'com.nineoldandroids:library:+'
+  compile 'com.nineoldandroids:library:19.1.+'
 }
 
 android {


### PR DESCRIPTION
Having a dependency on support-v4:+ causes gradle to use the new
support-v4 21.0.0-rc1 preview version, using any preview library will force
minSdk to L which through transitive dependencies will make any app depending
on slidingUpPanel to have minSdk on L
