### PR TITLE
Fix over-sliding of slidable view

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -640,6 +640,10 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 childHeightSpec = MeasureSpec.makeMeasureSpec(lp.height, MeasureSpec.EXACTLY);
             }
 
+            if (child == mSlideableView) {
+                mSlideRange = MeasureSpec.getSize(childHeightSpec) - mPanelHeight;
+            }
+
             child.measure(childWidthSpec, childHeightSpec);
         }
 


### PR DESCRIPTION
Calculate mSlideRange based on SlidableView's height fixes a display issue when slidable view is given a layout_height other than `match_parent`
