### PR TITLE
Apply parallax to the main view whenever mSlideOffset is changed.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -814,6 +814,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
         if (mFirstLayout) {
             updateObscuredViewVisibility();
         }
+        applyParallaxForCurrentSlideOffset();
 
         mFirstLayout = false;
     }
@@ -978,13 +979,12 @@ public class SlidingUpPanelLayout extends ViewGroup {
         }
     }
 
+    /**
+     * Update the parallax based on the current slide offset.
+     */
     @SuppressLint("NewApi")
-    private void onPanelDragged(int newTop) {
-        mSlideState = PanelState.DRAGGING;
-        // Recompute the slide offset based on the new top position
-        mSlideOffset = computeSlideOffset(newTop);
-        // Update the parallax based on the new slide offset
-        if (mParallaxOffset > 0 && mSlideOffset >= 0) {
+    private void applyParallaxForCurrentSlideOffset() {
+        if (mParallaxOffset > 0) {
             int mainViewOffset = getCurrentParalaxOffset();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
                 mMainView.setTranslationY(mainViewOffset);
@@ -992,6 +992,13 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 AnimatorProxy.wrap(mMainView).setTranslationY(mainViewOffset);
             }
         }
+    }
+
+    private void onPanelDragged(int newTop) {
+        mSlideState = PanelState.DRAGGING;
+        // Recompute the slide offset based on the new top position
+        mSlideOffset = computeSlideOffset(newTop);
+        applyParallaxForCurrentSlideOffset();
         // Dispatch the slide event
         dispatchOnPanelSlide(mSlideableView);
         // If the slide offset is negative, and overlay is not on, we need to increase the
@@ -1188,6 +1195,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
         public void onViewDragStateChanged(int state) {
             if (mDragHelper.getViewDragState() == ViewDragHelper.STATE_IDLE) {
                 mSlideOffset = computeSlideOffset(mSlideableView.getTop());
+                applyParallaxForCurrentSlideOffset();
 
                 if (mSlideOffset == 1) {
                     if (mSlideState != PanelState.EXPANDED) {


### PR DESCRIPTION
It fixes main view parallax when Sliding Up Panel is opened programmatically.
See https://github.com/umano/AndroidSlidingUpPanel/issues/371