### PR TITLE
swipe to anchor feature added

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -17,6 +17,7 @@
             <enum name="anchored" value="2" />
             <enum name="hidden" value="3" />
         </attr>
+        <attr name="umanoSwipeToAnchor" format="boolean"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Swipe to anchor feature added. I'm not sure if this is duplicate of #269, but I was not able to get that working.

If you set ```setSwipeToAnchor(true)``` (it's disabled by default) swiping will always stop at the specified anchor point instead of fully expanding/collapsing.
  