### PR TITLE
Make shadow drawable settable

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -94,7 +94,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     /**
      * Drawable used to draw the shadow between panes.
      */
-    private final Drawable mShadowDrawable;
+    private Drawable mShadowDrawable;
 
     /**
      * The size of the overhang in pixels.
@@ -424,6 +424,15 @@ public class SlidingUpPanelLayout extends ViewGroup {
 
     protected void smoothToBottom(){
         smoothSlideTo(0, 0);
+    }
+
+    /**
+     * Set the shadow drawable
+     *
+     * @param shadow A drawable to use as the shadow
+     */
+    public void setShadowDrawable(Drawable shadow) {
+        mShadowDrawable = shadow;
     }
 
     /**


### PR DESCRIPTION
If the panel is completely invisible initially, you may want to remove the shadow until the panel is visible. In the `PanelSlideListener`:

```java
@Override
public void onPanelSlide(View view, float v) {
    switch (panel.getPanelState()) {
        case COLLAPSED:
            // Collapsed height is 0dp, so we don't want the shadow
            // showing unless the panel is visible
            panel.setShadowDrawable(null);
            break;
        default:
            panel.setShadowDrawable(
                getResources().getDrawable(R.drawable.below_shadow)
            );
            break;
    }
}
```