### PR TITLE
Fixing SlidingUpPanelLayout::setEnableDragViewTouchEvents

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -882,7 +882,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 final int dragSlop = mDragHelper.getTouchSlop();
 
                 // Handle any horizontal scrolling on the drag view.
-                if (mIsUsingDragViewTouchEvents && adx > dragSlop && ady < dragSlop) {
+                if (mIsUsingDragViewTouchEvents && adx < dragSlop && ady > dragSlop) {
                     return super.onInterceptTouchEvent(ev);
                 }
 


### PR DESCRIPTION
The logic should be, if delta-Y is larger than drag-slop AND delta-X is smaller than drag-slop AND DragView has touch event handling, then do not intercept.