### PR TITLE
Add an interface for Parent view to negotiate with child Scrollable View.

### DIFF
--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -18,7 +18,16 @@
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
+        <activity
+            android:name="com.sothree.slidinguppanel.demo.ScrollableUpMenuActivity"
+            android:launchMode="singleTask"
+            android:label="Scrollable Up">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/demo/res/layout/activity_scrollable_up_menu.xml
+++ b/demo/res/layout/activity_scrollable_up_menu.xml
@@ -1,0 +1,40 @@
+<com.sothree.slidinguppanel.SlidingUpPanelLayout
+    android:id="@+id/drawer_layout"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:sothree="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="top"
+    sothree:umanoFadeColor="@android:color/transparent"
+    sothree:umanoFlingVelocity="2000"
+    sothree:umanoInitialState="expanded"
+    sothree:umanoOverlay="true"
+    sothree:umanoPanelHeight="80dp">
+
+
+    <RelativeLayout
+        android:id="@+id/main_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#ffff8800"
+        android:paddingTop="80dp">
+
+        <ListView
+            android:id="@+id/list1"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            />
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/top_menu"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#ffff4444">
+
+        <com.sothree.slidinguppanel.demo.MenuListView
+            android:id="@+id/list2"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+    </RelativeLayout>
+</com.sothree.slidinguppanel.SlidingUpPanelLayout>

--- a/demo/src/com/sothree/slidinguppanel/demo/MenuListView.java
+++ b/demo/src/com/sothree/slidinguppanel/demo/MenuListView.java
@@ -1,0 +1,79 @@
+package com.sothree.slidinguppanel.demo;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.widget.ListView;
+
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+/**
+ * Created by xiangzhc on 07/07/15.
+ */
+public class MenuListView extends ListView implements SlidingUpPanelLayout.TouchInterceptNegotiator  {
+    private boolean bottomReached;
+    private boolean scrollDisabled;
+
+    public MenuListView(Context context) {
+        this(context, null);
+    }
+
+    public MenuListView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public MenuListView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        onCreate();
+    }
+
+    public void disableScroll(boolean flag) {
+        scrollDisabled = flag;
+    }
+
+    private void onCreate() {
+        this.setOnScrollListener(new ScrollToEndDetector() {
+            @Override
+            public void onReachTop() {
+                bottomReached = false;
+            }
+
+            @Override
+            public void onReachBottom() {
+                bottomReached = true;
+            }
+
+            @Override
+            public void onReachNone() {
+                bottomReached = false;
+            }
+        });
+    }
+
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+
+        Log.v(getClass().getSimpleName(), "bottomReached =" + bottomReached + ", onTouchEvent(ev = " + ev + " )");
+
+        if (scrollDisabled) {
+            Log.v(getClass().getSimpleName(), "scrollDisabled =" + scrollDisabled);
+            return false;
+        }
+
+        return super.onTouchEvent(ev);
+    }
+
+    @Override
+    public boolean allowed(float mInitialMotionX, float mInitialMotionY, int dragSlop, MotionEvent ev) {
+        if (scrollDisabled)
+            return true;
+
+        if (bottomReached && mInitialMotionY - ev.getY() > dragSlop)
+            return true;
+        else
+            return false;
+    }
+
+}

--- a/demo/src/com/sothree/slidinguppanel/demo/ScrollToEndDetector.java
+++ b/demo/src/com/sothree/slidinguppanel/demo/ScrollToEndDetector.java
@@ -1,0 +1,72 @@
+package com.sothree.slidinguppanel.demo;
+
+import android.graphics.Rect;
+import android.util.Log;
+import android.view.View;
+import android.widget.AbsListView;
+
+/**
+ * Created by Administrator on 2015/7/2.
+ */
+abstract public class ScrollToEndDetector implements AbsListView.OnScrollListener {
+    private boolean topReached = true;/* Initial state of a listView*/
+    private boolean bottomReached = false;
+
+    @Override
+    public void onScrollStateChanged(AbsListView listView, int scrollState) {
+        _onScrollStateChanged(listView, scrollState);
+
+        if (topReached)
+            onReachTop();
+        else if (bottomReached)
+            onReachBottom();
+        else
+            onReachNone();
+
+    }
+
+    private void _onScrollStateChanged(AbsListView listView, int scrollState) {
+        if (scrollState == SCROLL_STATE_IDLE) {
+            if (listView.getFirstVisiblePosition() == 0) {
+                final View firstVisibleView = listView.getChildAt(0);
+                if (firstVisibleView != null && isAllShown(listView, firstVisibleView)){
+                    topReached = true;
+                    bottomReached = false;
+                    return;
+                }
+            } else if (listView.getLastVisiblePosition() == listView.getCount() - 1) {
+                final View lastVisibleView = listView.getChildAt(listView.getChildCount() - 1);
+                if (lastVisibleView != null && isAllShown(listView, lastVisibleView)) {
+                    topReached = false;
+                    bottomReached = true;
+                    return;
+                }
+            }
+
+
+            topReached = bottomReached = false;
+            return;
+        }
+    }
+
+    private boolean isAllShown(AbsListView listView, View itemView) {
+        final Rect r = new Rect(0, 0, itemView.getWidth(), itemView.getHeight());
+        final double height = itemView.getHeight () * 1.0;
+
+        listView.getChildVisibleRect(itemView, r, null);
+        Log.d("Visible1 ", "  " + height + "  " + r.height());
+        if ( height == r.height())
+            return true;
+
+        return false;
+    }
+
+    @Override
+    public void onScroll(AbsListView view, final int firstVisibleItem, final int visibleItemCount, final int totalItemCount) {
+
+    }
+
+    abstract public void onReachTop();
+    abstract public void onReachBottom();
+    abstract public void onReachNone();
+}

--- a/demo/src/com/sothree/slidinguppanel/demo/ScrollableUpMenuActivity.java
+++ b/demo/src/com/sothree/slidinguppanel/demo/ScrollableUpMenuActivity.java
@@ -1,0 +1,72 @@
+package com.sothree.slidinguppanel.demo;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+
+public class ScrollableUpMenuActivity extends ActionBarActivity {
+    SlidingUpPanelLayout rootView;
+    ListView mainContentList;
+    MenuListView menuList;
+
+    private void constructListViews() {
+        String[] items = { "Milk", "Butter", "Yogurt", "Toothpaste", "Ice Cream", "Milk", "Butter", "Yogurt", "Toothpaste", "Ice Cream",  "Milk", "Butter", "Yogurt", "Toothpaste", "Ice Cream", "Milk", "Butter", "Yogurt", "Toothpaste", "Ice Cream" };
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, items);
+
+        mainContentList.setAdapter(adapter);
+        menuList.setAdapter(adapter);
+
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_scrollable_up_menu);
+
+        rootView = (SlidingUpPanelLayout)findViewById(R.id.drawer_layout);
+        mainContentList = (ListView)findViewById(R.id.list1);
+        menuList = (MenuListView)findViewById(R.id.list2);
+
+        constructListViews();
+        rootView.setNegotiator(menuList);
+        rootView.setEnableDragViewTouchEvents(true);
+        rootView.setPanelSlideListener(new SlidingUpPanelLayout.PanelSlideListener() {
+            @Override
+            public void onPanelSlide(View view, float v) {
+
+            }
+
+            @Override
+            public void onPanelCollapsed(View view) {
+                menuList.disableScroll(true);
+            }
+
+            @Override
+            public void onPanelExpanded(View view) {
+                menuList.disableScroll(false);
+
+            }
+
+            @Override
+            public void onPanelAnchored(View view) {
+
+            }
+
+            @Override
+            public void onPanelHidden(View view) {
+
+            }
+        });
+    }
+
+
+
+}

--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -882,7 +882,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 final int dragSlop = mDragHelper.getTouchSlop();
 
                 // Handle any horizontal scrolling on the drag view.
-                if (mIsUsingDragViewTouchEvents && adx > dragSlop && ady < dragSlop) {
+                if (mIsUsingDragViewTouchEvents && adx < dragSlop && ady > dragSlop) {
                     return super.onInterceptTouchEvent(ev);
                 }
 


### PR DESCRIPTION
Use case: Assume a sliding-up-menu child is also a Scrollable (e.g. ListView/RecyclerView/ScrollView). A common requirement is if the child has scroll to topmost, then any scroll-down should be handled by SlidingUpPanelLayout, i.e. when the menu is on its topmost position, any scroll-down gesture would close the menu. 

To achieve this, The parent SlidingUpPanelLayout needs to consult if the child has been on its topmost position. If yes, the parent would **INTERCEPT** the whole gesture. Otherwise the parent would simply have the child to handle it.