### PR TITLE
Fixed drag state idle check

### DIFF
--- a/library/src/com/sothree/slidinguppanel/ViewDragHelper.java
+++ b/library/src/com/sothree/slidinguppanel/ViewDragHelper.java
@@ -871,7 +871,7 @@ public class ViewDragHelper {
         if (mDragState != state) {
             mDragState = state;
             mCallback.onViewDragStateChanged(state);
-            if (state == STATE_IDLE) {
+            if (mDragState == STATE_IDLE) {
                 mCapturedView = null;
             }
         }


### PR DESCRIPTION
Had a case where I had to conditionally change the panel state from within a callback (since it's not possible to change state while dragging). This was messing it up.