### PR TITLE
Fixed anchor point scrolling issue. If anchor point is set, then the …

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1373,21 +1373,23 @@ public class SlidingUpPanelLayout extends ViewGroup {
             // direction is always positive if we are sliding in the expanded direction
             float direction = mIsSlidingUp ? -yvel : yvel;
 
-            if (direction > 0) {
-                // swipe up -> expand
-                target = computePanelTopPosition(1.0f);
-            } else if (direction < 0) {
-                // swipe down -> collapse
-                target = computePanelTopPosition(0.0f);
-            } else if (mAnchorPoint != 1 && mSlideOffset >= (1.f + mAnchorPoint) / 2) {
-                // zero velocity, and far enough from anchor point => expand to the top
-                target = computePanelTopPosition(1.0f);
-            } else if (mAnchorPoint == 1 && mSlideOffset >= 0.5f) {
-                // zero velocity, and far enough from anchor point => expand to the top
-                target = computePanelTopPosition(1.0f);
-            } else if (mAnchorPoint != 1 && mSlideOffset >= mAnchorPoint) {
+            if (direction > 0 && mSlideOffset <= mAnchorPoint) {
+                // swipe up -> expand and stop at anchor point
                 target = computePanelTopPosition(mAnchorPoint);
-            } else if (mAnchorPoint != 1 && mSlideOffset >= mAnchorPoint / 2) {
+            } else if (direction > 0 && mSlideOffset > mAnchorPoint) {
+                // swipe up past anchor -> expand
+                target = computePanelTopPosition(1.0f);
+            } else if (direction < 0 && mSlideOffset >= mAnchorPoint) {
+                // swipe down -> collapse and stop at anchor point
+                target = computePanelTopPosition(mAnchorPoint);
+            } else if (direction < 0 && mSlideOffset < mAnchorPoint) {
+                // swipe down past anchor -> collapse
+                target = computePanelTopPosition(0.0f);
+            } else if (mSlideOffset >= (1.f + mAnchorPoint) / 2) {
+                // zero velocity, and far enough from anchor point => expand to the top
+                target = computePanelTopPosition(1.0f);
+            } else if (mSlideOffset >= mAnchorPoint / 2) {
+                // zero velocity, and close enough to anchor point => go to anchor
                 target = computePanelTopPosition(mAnchorPoint);
             } else {
                 // settle at the bottom


### PR DESCRIPTION
If anchor point is set, then the panel will stop at the anchor point first before going to the expanded or collapsed state. This is unless the user has scrolled past the anchor point.

I have also removed unnecessary conditions and simplified the if statements in onViewReleased()