### PR TITLE
Dragging from close to the edge of the panel doesn't work as expected.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/ViewDragHelper.java
+++ b/library/src/com/sothree/slidinguppanel/ViewDragHelper.java
@@ -1144,7 +1144,7 @@ public class ViewDragHelper {
                             break;
                         }
 
-                        final View toCapture = findTopChildUnder((int) x, (int) y);
+                        final View toCapture = findTopChildUnder((int) mInitialMotionX[pointerId], (int) mInitialMotionY[pointerId]);
                         if (checkTouchSlop(toCapture, dx, dy) &&
                                 tryCaptureViewForDrag(toCapture, pointerId)) {
                             break;


### PR DESCRIPTION
When checking to see if we've passed drag slop, use the initial position of the cursor, not the moved position to get the view.

This was causing dragging from close to the panel edge to not work correctly.