### PR TITLE
Make recyclerview dependency optional.

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -26,10 +26,12 @@ import android.widget.ScrollView;
 
 import com.nineoldandroids.view.animation.AnimatorProxy;
 import com.sothree.slidinguppanel.library.R;
+import com.sothree.slidinguppanel.util.ReflectionUtils;
 
 public class SlidingUpPanelLayout extends ViewGroup {
 
     private static final String TAG = SlidingUpPanelLayout.class.getSimpleName();
+    private static final boolean RECYCLER_AVAILABLE = ReflectionUtils.isClassPresent("android.support.v7.widget.RecyclerView");
 
     /**
      * Default peeking out panel height
@@ -1051,7 +1053,8 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 // Approximate the scroll position based on the bottom child and the last visible item
                 return (lv.getAdapter().getCount() - lv.getLastVisiblePosition() - 1) * lastChild.getHeight() + lastChild.getBottom() - lv.getBottom();
             }
-        } else if (mScrollableView instanceof RecyclerView && ((RecyclerView) mScrollableView).getChildCount() > 0) {
+        } else if (RECYCLER_AVAILABLE &&
+                mScrollableView instanceof RecyclerView && ((RecyclerView) mScrollableView).getChildCount() > 0) {
             RecyclerView rv = ((RecyclerView) mScrollableView);
             RecyclerView.LayoutManager lm = rv.getLayoutManager();
             if (rv.getAdapter() == null) return 0;

--- a/library/src/com/sothree/slidinguppanel/util/ReflectionUtils.java
+++ b/library/src/com/sothree/slidinguppanel/util/ReflectionUtils.java
@@ -1,0 +1,17 @@
+package com.sothree.slidinguppanel.util;
+
+public class ReflectionUtils {
+    private ReflectionUtils() {
+        throw new AssertionError("No instances.");
+    }
+
+    public static boolean isClassPresent(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (Throwable ex) {
+            // Class or one of its dependencies is not present...
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
RecyclerView is not a part of the core functionality and it should be possible to use library without bundled dependency for projects where only ScrollView or ListView are used with 

```
compile ('com.android.support:recyclerview-v7:22.2.1'){
    exclude group: 'com.android.support', module: 'recyclerview-v7'
  }
```