### PR TITLE
Have a default state for mLastNotDraggingSlideState

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -174,7 +174,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     /**
      * If the current slide state is DRAGGING, this will store the last non dragging state
      */
-    private PanelState mLastNotDraggingSlideState = null;
+    private PanelState mLastNotDraggingSlideState = DEFAULT_SLIDE_STATE;
 
     /**
      * How far the panel is offset from its expanded position.


### PR DESCRIPTION
This variable is used to store the saved instance state for the activity, therefore if `null` will cause  he parcel serialization to fail with a NPE. It's not entirely clear to me in what circumstances this can actually happen and I can't reproduce it (even though we see crashes in our crashlytics reports), but there's definitely a code path that leads to the NPE (`ss.mSlideState = mLastNotDraggingSlideState` at line 1360 in `SlidingUpPanelLayout.java`).

We've been running this patch internally for a while and we haven't seen any more crashes.

Fixes #536.
