### PR TITLE
Handle HorizontalScrollView within scrollable view

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -938,6 +938,24 @@ public class SlidingUpPanelLayout extends ViewGroup {
         }
     }
 
+    private boolean isOverHorizontalScrollView(View view, int x, int y) {
+        if (isViewUnder(view, x, y)) {
+            if (view instanceof HorizontalScrollView) {
+                return true;
+            }
+            if (view instanceof ViewGroup) {
+                ViewGroup viewGroup = (ViewGroup) view;
+                for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                    View child = viewGroup.getChildAt(i);
+                    if (isOverHorizontalScrollView(child, x, y)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean dispatchTouchEvent(@NonNull MotionEvent ev) {
         final int action = MotionEventCompat.getActionMasked(ev);
@@ -959,6 +977,10 @@ public class SlidingUpPanelLayout extends ViewGroup {
             // If the scroll view isn't under the touch, pass the
             // event along to the dragView.
             if (!isViewUnder(mScrollableView, (int) mInitialMotionX, (int) mInitialMotionY)) {
+                return super.dispatchTouchEvent(ev);
+            }
+
+            if (isOverHorizontalScrollView(mScrollableView, (int) mInitialMotionX, (int) mInitialMotionY)) {
                 return super.dispatchTouchEvent(ev);
             }
 


### PR DESCRIPTION
When a HorizontalScrollView is embedded within a ScrollView which is set as the panel's scrollable view, the HorizontalScrollView does not scroll properly. Since the HorizontalScrollView scrolls properly if the ScrollView is not set as the panel's scrollable view, adding a check to ignore the portion of the scrollable view that contains a HorizontalScrollView works to allow both the HorizontalScrollView and the ScrollView to function properly.