### PR TITLE
Added toggle, which enables to hide panel with gesture.

### DIFF
--- a/demo/res/layout/activity_demo.xml
+++ b/demo/res/layout/activity_demo.xml
@@ -15,7 +15,8 @@
         sothree:umanoParallaxOffset="100dp"
         sothree:umanoDragView="@+id/dragView"
         sothree:umanoOverlay="true"
-        sothree:umanoScrollableView="@+id/list">
+        sothree:umanoScrollableView="@+id/list"
+        sothree:umanoHideWithFling="true">
 
         <!-- MAIN CONTENT -->
         <FrameLayout

--- a/demo/src/com/sothree/slidinguppanel/demo/DemoActivity.java
+++ b/demo/src/com/sothree/slidinguppanel/demo/DemoActivity.java
@@ -30,6 +30,7 @@ public class DemoActivity extends ActionBarActivity {
     private static final String TAG = "DemoActivity";
 
     private SlidingUpPanelLayout mLayout;
+	private TextView mText;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -93,13 +94,13 @@ public class DemoActivity extends ActionBarActivity {
             @Override
             public void onPanelExpanded(View panel) {
                 Log.i(TAG, "onPanelExpanded");
-
+				mText.setText("Panel is expanded");
             }
 
             @Override
             public void onPanelCollapsed(View panel) {
                 Log.i(TAG, "onPanelCollapsed");
-
+	            mText.setText("Panel is collapsed");
             }
 
             @Override
@@ -110,8 +111,17 @@ public class DemoActivity extends ActionBarActivity {
             @Override
             public void onPanelHidden(View panel) {
                 Log.i(TAG, "onPanelHidden");
+	            mText.setText("Panel is hidden. Click to show panel");
             }
         });
+
+		mText = (TextView) findViewById(R.id.main);
+		mText.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				mLayout.setPanelState(PanelState.COLLAPSED);
+			}
+		});
 
         TextView t = (TextView) findViewById(R.id.name);
         t.setText(Html.fromHtml(getString(R.string.hello)));

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -12,6 +12,7 @@
         <attr name="umanoOverlay" format="boolean"/>
         <attr name="umanoClipPanel" format="boolean"/>
         <attr name="umanoAnchorPoint" format="float" />
+        <attr name="umanoHideWithFling" format="boolean" />
         <attr name="umanoInitialState" format="enum">
             <enum name="expanded" value="0" />
             <enum name="collapsed" value="1" />


### PR DESCRIPTION
Added toggle, which enables to hide panel with fling down gesture. So, in case user drags below anchor point and velocity is enough, panel will be hidden instead of collapsed.

Also demo is updated, in order to show usage of the property.