### PR TITLE
Added support to NestedScrollView in getScrollableViewScrollPosition …

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1072,6 +1072,14 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 // Approximate the scroll position based on the bottom child and the last visible item
                 return (rv.getAdapter().getItemCount() - 1) * lm.getDecoratedMeasuredHeight(lastChild) + lm.getDecoratedBottom(lastChild) - rv.getBottom();
             }
+        } else if (mScrollableView instanceof NestedScrollView) {
+            if(mIsSlidingUp){
+                return mScrollableView.getScrollY();
+            } else {
+                NestedScrollView nsv = ((NestedScrollView) mScrollableView);
+                View child = nsv.getChildAt(0);
+                return (child.getBottom() - (nsv.getHeight() + nsv.getScrollY()));
+            }
         } else {
             return 0;
         }


### PR DESCRIPTION
…method

Hi,

I realised that the library offered support to ScrollView but not to NestedScrollView and I changed the getScrollableViewScrollPosition method in order to resolve it.

NestedScrollView is mainly used to be able to use a ScrollView as child of the CoordinatorLayout since ScrollView is only thought to be used as parent.

Waiting for your response and thanks for the awesome work here,

Ignacio
