### PR TITLE
Added support to views which have collapsing toolbar

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="umanoFlingVelocity" format="integer" />
         <attr name="umanoDragView" format="reference" />
         <attr name="umanoScrollableView" format="reference" />
+        <attr name="umanoAppBarView" format="reference" />
         <attr name="umanoOverlay" format="boolean"/>
         <attr name="umanoClipPanel" format="boolean"/>
         <attr name="umanoAnchorPoint" format="float" />


### PR DESCRIPTION
Hi,

I've added some support to be able to use the library in views that have AppBar containing a CollapsingToolbarLayout which is used to have a similar effect than the contacts application of google, e.g.:
https://www.youtube.com/watch?v=2kwZ5Qb6pL8

Now the panel won't hide until the toolbar is properly fully expanded.

Waiting for your response.

Best and thank you,

Ignacio
