### PR TITLE
Fix state handling after rotation with different anchor points

### DIFF
--- a/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -822,6 +822,10 @@ public class SlidingUpPanelLayout extends ViewGroup {
 
         final int childCount = getChildCount();
 
+        if (mSlideState == EXPANDED && mAnchor < 1.0f) {
+            mSlideState = ANCHORED;
+        }
+        
         if (mFirstLayout) {
             switch (mSlideState) {
                 case EXPANDED:


### PR DESCRIPTION
If you set the anchor point to 
* 1.0f in landscape
* 0.6f in portrait for instance

Then the state in landscape, when the panel is open, is saved as extended.
After the rotation, it will appear extended again but it should be anchored as the anchor point is 0.6f.