### PR TITLE
Added start callbacks to PanelSlideListener

### DIFF
--- a/demo/src/com/sothree/slidinguppanel/demo/DemoActivity.java
+++ b/demo/src/com/sothree/slidinguppanel/demo/DemoActivity.java
@@ -97,9 +97,19 @@ public class DemoActivity extends ActionBarActivity {
             }
 
             @Override
+            public void onStartPanelExpandFromCollapsed(View panel) {
+                Log.i(TAG, "onStartPanelExpandFromCollapsed");
+            }
+
+            @Override
             public void onPanelCollapsed(View panel) {
                 Log.i(TAG, "onPanelCollapsed");
 
+            }
+
+            @Override
+            public void onStartPanelCollapseFromExpanded(View panel, boolean toHidden) {
+                Log.i(TAG, "onStartPanelCollapseFromExpanded: toHidden="+toHidden);
             }
 
             @Override


### PR DESCRIPTION
Added callbacks to `PanelSlideListener`, for when the panel state starts changing from collapsed to expanded and vice versa. This can be useful, if other UI elements need to start changing already when the state transition begins.

Added `StartPanelSlideListener`, which behaves like the normal `PanelSlideListener` for collapse and expand events, except that it executes on slide start and automatically handles the case when state change does not finish by calling the other callback again.