### PR TITLE
Updated maven_push.gradle to the latest version.

### DIFF
--- a/maven_push.gradle
+++ b/maven_push.gradle
@@ -1,13 +1,42 @@
+/*
+ * Copyright 2013 Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def sonatypeRepositoryUrl
-if (isReleaseBuild()) {
-    println 'RELEASE BUILD'
-    sonatypeRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-} else {
-    println 'DEBUG BUILD'
-    sonatypeRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
 afterEvaluate { project ->
@@ -16,10 +45,15 @@ afterEvaluate { project ->
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
+                pom.groupId = GROUP
                 pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
 
-                repository(url: sonatypeRepositoryUrl) {
-                    authentication(userName: nexusUsername, password: nexusPassword)
+                repository(url: getReleaseRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
                 }
 
                 pom.project {
@@ -60,22 +94,20 @@ afterEvaluate { project ->
 
     task androidJavadocs(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }
 
-    task androidJavadocsJar(type: Jar) {
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
         classifier = 'javadoc'
-        //basename = artifact_id
         from androidJavadocs.destinationDir
     }
 
     task androidSourcesJar(type: Jar) {
         classifier = 'sources'
-        //basename = artifact_id
-        from android.sourceSets.main.java.srcDirs
+        from android.sourceSets.main.java.sourceFiles
     }
 
     artifacts {
-        //archives packageReleaseJar
         archives androidSourcesJar
         archives androidJavadocsJar
     }


### PR DESCRIPTION
This version of the `maven_push` gradle script includes getters for username and password (`getRepositoryUsername` and `getRepositoryPassword`) so the build will not fail if the nexus username and password are not set in the `gradle.properties` file. It defaults them to empty strings if they are not available.

Note that the values in this version of the script get the username from `NEXUS_USERNAME` and `NEXUS_PASSWORD` instead of the current `nexusUsername` and `nexusPassword`.

This change will also enable [jitpack](https://jitpack.io) to build the project. Currently there isn't a recent `SNAPSHOT` build available and I'd like to be able to reference a recent commit that has a feature I want. In the example below I can add a commit or use the latest from this repo's `master` branch (`-SNAPSHOT`) in order to do so:

```groovy
allprojects {
    repositories {
        maven { url "https://jitpack.io" }
    }
}
```

```groovy
dependencies {
  ...
  compile 'com.github.umano:androidslidinguppanel:-SNAPSHOT'
}
```

The difference in this change can be seen in the logs below at jitpack:

[The log with the updated maven_push.gradle file in this branch:](https://jitpack.io/com/github/dvoiss/androidslidinguppanel/-3.2.0-gedef439-43/build.log)

`BUILD SUCCESSFUL`

[The log of the current result:](https://jitpack.io/com/github/umano/androidslidinguppanel/-3.2.0-gb4baf27-42/build.log)

```
A problem occurred configuring project ':demo'.
> A problem occurred configuring project ':library'.
   > No such property: nexusUsername for class: org.gradle.api.publication.maven.internal.deployer.DefaultGroovyMavenDeployer
```