### PR TITLE
Fix NPE in drawChild() when returning to Fragment with animation. App…

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1154,7 +1154,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
         boolean result;
         final int save = canvas.save(Canvas.CLIP_SAVE_FLAG);
 
-        if (mSlideableView != child) { // if main view
+        if (mSlideableView != null && mSlideableView != child) { // if main view
             // Clip against the slider; no sense drawing what will immediately be covered,
             // Unless the panel is set to overlay content
             canvas.getClipBounds(mTmpRect);


### PR DESCRIPTION
This appears very similar to Issue #599 in umano/AndroidSlidingUpPanel. I have a sliding up panel in 2 fragments, one visible and one on the backstack. I pop the backstack below both fragments with sliding up panels and get an NPE in drawChild with mSlideabloeView being null.  Put in a check for mSlideableView != null.
