### PR TITLE
fixed backwards compatibility for API 8 (#694)

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -9,7 +9,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 11
+    minSdkVersion 8
     targetSdkVersion 23
   }
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="3.3.0">
 
     <uses-sdk
-        android:minSdkVersion="11"
+        android:minSdkVersion="8"
         android:targetSdkVersion="17" />
 
     <application

--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -896,6 +896,8 @@ public class SlidingUpPanelLayout extends ViewGroup {
                     return false;
                 }
                 break;
+
+
             }
 
             case MotionEvent.ACTION_CANCEL:
@@ -1033,10 +1035,14 @@ public class SlidingUpPanelLayout extends ViewGroup {
     private int computePanelTopPosition(float slideOffset) {
         int slidingViewHeight = mSlideableView != null ? mSlideableView.getMeasuredHeight() : 0;
         int slidePixelOffset = (int) (slideOffset * mSlideRange);
+
+        // fix for issue #694
+        int bottomPanelValue = getMeasuredHeight() - getPaddingBottom() - mPanelHeight - slidePixelOffset;
+        int topPanelValue = getPaddingTop() - slidingViewHeight + mPanelHeight + slidePixelOffset;
+
+
         // Compute the top of the panel if its collapsed
-        return mIsSlidingUp
-                ? getMeasuredHeight() - getPaddingBottom() - mPanelHeight - slidePixelOffset
-                : getPaddingTop() - slidingViewHeight + mPanelHeight + slidePixelOffset;
+        return mIsSlidingUp ? bottomPanelValue : topPanelValue;
     }
 
     /*

--- a/library/src/main/java/com/sothree/slidinguppanel/ViewDragHelper.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/ViewDragHelper.java
@@ -18,6 +18,7 @@
 package com.sothree.slidinguppanel;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
 import android.support.v4.view.VelocityTrackerCompat;
 import android.support.v4.view.ViewCompat;
@@ -756,7 +757,10 @@ public class ViewDragHelper {
             
             if(!keepGoing && dy != 0) { //fix #525
                 //Invalid drag state
-                mCapturedView.setTop(0);
+                // fix #694 catch SDK for backwards compatibility, View.setTop(int) is an API 11 call
+                if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                    mCapturedView.setTop(0);
+                }
                 return true;
             }
 


### PR DESCRIPTION
Fixes strange sliding behavior for API <11 as mentioned in issue #694 and slight fix to catch API 11 call introduced in issue #525 


** I'm not very familiar (yet) with pulling/pushing remotes, please let me know if I make mistakes in procedure/form, or if anything needs changing.