### PR TITLE
Bugfix: java.util.ConcurrentModificationException on mPanelSlideListeners

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -495,7 +495,9 @@ public class SlidingUpPanelLayout extends ViewGroup {
      * @param listener
      */
     public void addPanelSlideListener(PanelSlideListener listener) {
-        mPanelSlideListeners.add(listener);
+        synchronized (mPanelSlideListeners) {
+            mPanelSlideListeners.add(listener);
+        }
     }
 
     /**
@@ -504,7 +506,9 @@ public class SlidingUpPanelLayout extends ViewGroup {
      * @param listener
      */
     public void removePanelSlideListener(PanelSlideListener listener) {
-        mPanelSlideListeners.remove(listener);
+        synchronized (mPanelSlideListeners) {
+            mPanelSlideListeners.remove(listener);
+        }
     }
 
     /**
@@ -633,15 +637,21 @@ public class SlidingUpPanelLayout extends ViewGroup {
         return mClipPanel;
     }
 
+
     void dispatchOnPanelSlide(View panel) {
-        for (PanelSlideListener l : mPanelSlideListeners) {
-            l.onPanelSlide(panel, mSlideOffset);
+        synchronized (mPanelSlideListeners) {
+            for (PanelSlideListener l : mPanelSlideListeners) {
+                l.onPanelSlide(panel, mSlideOffset);
+            }
         }
     }
 
+
     void dispatchOnPanelStateChanged(View panel, PanelState previousState, PanelState newState) {
-        for (PanelSlideListener l : mPanelSlideListeners) {
-            l.onPanelStateChanged(panel, previousState, newState);
+        synchronized (mPanelSlideListeners) {
+            for (PanelSlideListener l : mPanelSlideListeners) {
+                l.onPanelStateChanged(panel, previousState, newState);
+            }
         }
         sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
     }


### PR DESCRIPTION
With the lastest version of the AndroidSlidingUpPanel we receiving some crashes with the following exception:

java.util.ConcurrentModificationException
	at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
	at com.sothree.slidinguppanel.SlidingUpPanelLayout.dispatchOnPanelStateChanged(SourceFile:643)
	at com.sothree.slidinguppanel.SlidingUpPanelLayout.setPanelStateInternal(SourceFile:1108)
	at com.sothree.slidinguppanel.SlidingUpPanelLayout.access$100(SourceFile:32)
                                                    access$602
                                                    access$700
                                                    access$900
	at com.sothree.slidinguppanel.SlidingUpPanelLayout$DragHelperCallback.onViewDragStateChanged(SourceFile:1340)
	at com.sothree.slidinguppanel.ViewDragHelper.setDragState(SourceFile:911)
	at com.sothree.slidinguppanel.ViewDragHelper$2.run(SourceFile:336)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:145)
	at android.app.ActivityThread.main(ActivityThread.java:6145)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1399)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1194)

With this pull request, i'll hope to fix this problem. I know it's a not the best solution, but even better than crashing the app :(