### PR TITLE
Save wrong state while dragging or in drag motion

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1124,7 +1124,9 @@ public class SlidingUpPanelLayout extends ViewGroup {
     }
 
     private void onPanelDragged(int newTop) {
-        mLastNotDraggingSlideState = mSlideState;
+        if (mSlideState != PanelState.DRAGGING) {
+            mLastNotDraggingSlideState = mSlideState;
+        }
         setPanelStateInternal(PanelState.DRAGGING);
         // Recompute the slide offset based on the new top position
         mSlideOffset = computeSlideOffset(newTop);


### PR DESCRIPTION
if we do a drag or set different panel state to make it dragging, then goes into save state immediately (fragment replaced into back stack or activity kill by system), panel state will be saved as DRAGGING and after view restore it will break down the whole logic.