### PR TITLE
In SlidingUpPanelLayout.dispatchTouchEvent(), ignore horizontal scrolls

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -207,6 +207,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
      */
     private boolean mIsTouchEnabled;
 
+    private float mPrevMotionX;
     private float mPrevMotionY;
     private float mInitialMotionX;
     private float mInitialMotionY;
@@ -961,14 +962,23 @@ public class SlidingUpPanelLayout extends ViewGroup {
             return super.dispatchTouchEvent(ev);
         }
 
+        final float x = ev.getX();
         final float y = ev.getY();
 
         if (action == MotionEvent.ACTION_DOWN) {
             mIsScrollableViewHandlingTouch = false;
+            mPrevMotionX = x;
             mPrevMotionY = y;
         } else if (action == MotionEvent.ACTION_MOVE) {
+            float dx = x - mPrevMotionX;
             float dy = y - mPrevMotionY;
+            mPrevMotionX = x;
             mPrevMotionY = y;
+
+            if (Math.abs(dx) > Math.abs(dy)) {
+                // Scrolling horizontally, so ignore
+                return super.dispatchTouchEvent(ev);
+            }
 
             // If the scroll view isn't under the touch, pass the
             // event along to the dragView.


### PR DESCRIPTION
This will allow child views with horizontally scrollable content to behave as expected, regardless of the state of the panel.

--------

My specific issue is this: I have a `RecyclerView` which has a `LinearLayoutManager` with a horizontal orientation. This `RecyclerView` is one of many children inside a `ScrollView`, and of course, this `ScrollView` is set as the scrollable view in the `SlidingUpPanelLayout`.

When the panel was in the `COLLAPSED` or `ANCHORED` states, horizontal scrolls on this `RecyclerView` were awkward. They felt sluggish, and often weren't handled properly.

I would also expect this code change to fix the issue reported in https://github.com/umano/AndroidSlidingUpPanel/issues/679.