### PR TITLE
Change access of method smoothSlideTo() to public

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1227,7 +1227,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
      * @param slideOffset position to animate to
      * @param velocity    initial velocity in case of fling, or 0.
      */
-    boolean smoothSlideTo(float slideOffset, int velocity) {
+    public boolean smoothSlideTo(float slideOffset, int velocity) {
         if (!isEnabled() || mSlideableView == null) {
             // Nothing to do.
             return false;


### PR DESCRIPTION
Since there is no option to directly scroll the panel to an arbitrary position, it would be very useful if an library user could access this method, so this would be made possible.

I currently use this feature through reflection to show a quick "peek" (~15% height for 1.2sec) of the sliding panel to communicate to the user that this part of the UI can be dragged.