### PR TITLE
Changed 'compile' into implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dependencies {
     repositories {
         mavenCentral()
     }
-    compile 'com.sothree.slidinguppanel:library:3.4.0'
+    implementation 'com.sothree.slidinguppanel:library:3.4.0'
 }
 ```
 


### PR DESCRIPTION
To solve the issues regarding: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.