### PR TITLE
You can set `umanoSlide` if you want the sliding panel to follow inertial movement after released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ or `?attr/actionBarSize` to support older API versions.
 * Use `getPanelState` to get the current panel state
 * Use `setPanelState` to set the current panel state
 * You can add parallax to the main view by setting `umanoParallaxOffset` attribute (see demo for the example).
-* You can set `umanoFlint` if you want the sliding panel to follow inertial movement after released.
+* You can set `umanoSlide` if you want the sliding panel to follow inertial movement after released.
 * You can set a anchor point in the middle of the screen using `setAnchorPoint` to allow an intermediate expanded state for the panel (similar to Google Maps).
 * You can set a `PanelSlideListener` to monitor events about sliding panes.
 * You can also make the panel slide from the top by changing the `layout_gravity` attribute of the layout to `top`.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ or `?attr/actionBarSize` to support older API versions.
 * Use `getPanelState` to get the current panel state
 * Use `setPanelState` to set the current panel state
 * You can add parallax to the main view by setting `umanoParallaxOffset` attribute (see demo for the example).
+* You can set `umanoFlint` if you want the sliding panel to follow inertial movement after released.
 * You can set a anchor point in the middle of the screen using `setAnchorPoint` to allow an intermediate expanded state for the panel (similar to Google Maps).
 * You can set a `PanelSlideListener` to monitor events about sliding panes.
 * You can also make the panel slide from the top by changing the `layout_gravity` attribute of the layout to `top`.

--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -135,6 +135,11 @@ public class SlidingUpPanelLayout extends ViewGroup {
     private boolean mClipPanel = DEFAULT_CLIP_PANEL_FLAG;
 
     /**
+     * If the panel should flint instead of attaching after move
+     */
+    private boolean mFlint = false;
+
+    /**
      * If provided, the panel can be dragged by only this view. Otherwise, the entire panel can be
      * used for dragging.
      */
@@ -305,6 +310,8 @@ public class SlidingUpPanelLayout extends ViewGroup {
 
                 mOverlayContent = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoOverlay, DEFAULT_OVERLAY_FLAG);
                 mClipPanel = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoClipPanel, DEFAULT_CLIP_PANEL_FLAG);
+
+                mFlint = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoFlint, false);
 
                 mAnchorPoint = ta.getFloat(R.styleable.SlidingUpPanelLayout_umanoAnchorPoint, DEFAULT_ANCHOR_POINT);
 
@@ -1421,8 +1428,11 @@ public class SlidingUpPanelLayout extends ViewGroup {
             }
 
             if (mDragHelper != null) {
-//                mDragHelper.settleCapturedViewAt(releasedChild.getLeft(), target);
-                mDragHelper.flingCapturedView(0, 0, 0, getBottom() - mPanelHeight);
+                if (mFlint) {
+                    mDragHelper.flingCapturedView(0, 0, 0, getBottom() - mPanelHeight);
+                } else {
+                    mDragHelper.settleCapturedViewAt(releasedChild.getLeft(), target);
+                }
             }
             invalidate();
         }

--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -1421,7 +1421,8 @@ public class SlidingUpPanelLayout extends ViewGroup {
             }
 
             if (mDragHelper != null) {
-                mDragHelper.settleCapturedViewAt(releasedChild.getLeft(), target);
+//                mDragHelper.settleCapturedViewAt(releasedChild.getLeft(), target);
+                mDragHelper.flingCapturedView(0, 0, 0, getBottom() - mPanelHeight);
             }
             invalidate();
         }

--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -135,9 +135,9 @@ public class SlidingUpPanelLayout extends ViewGroup {
     private boolean mClipPanel = DEFAULT_CLIP_PANEL_FLAG;
 
     /**
-     * If the panel should flint instead of attaching after move
+     * If the panel should slide instead of attaching after move
      */
-    private boolean mFlint = false;
+    private boolean mSlide = false;
 
     /**
      * If provided, the panel can be dragged by only this view. Otherwise, the entire panel can be
@@ -311,7 +311,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
                 mOverlayContent = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoOverlay, DEFAULT_OVERLAY_FLAG);
                 mClipPanel = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoClipPanel, DEFAULT_CLIP_PANEL_FLAG);
 
-                mFlint = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoFlint, false);
+                mSlide = ta.getBoolean(R.styleable.SlidingUpPanelLayout_umanoSlide, false);
 
                 mAnchorPoint = ta.getFloat(R.styleable.SlidingUpPanelLayout_umanoAnchorPoint, DEFAULT_ANCHOR_POINT);
 
@@ -1428,7 +1428,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
             }
 
             if (mDragHelper != null) {
-                if (mFlint) {
+                if (mSlide) {
                     mDragHelper.flingCapturedView(0, 0, 0, getBottom() - mPanelHeight);
                 } else {
                     mDragHelper.settleCapturedViewAt(releasedChild.getLeft(), target);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -10,7 +10,7 @@
         <attr name="umanoDragView" format="reference" />
         <attr name="umanoScrollableView" format="reference" />
         <attr name="umanoOverlay" format="boolean"/>
-        <attr name="umanoFlint" format="boolean"/>
+        <attr name="umanoSlide" format="boolean"/>
         <attr name="umanoClipPanel" format="boolean"/>
         <attr name="umanoAnchorPoint" format="float" />
         <attr name="umanoInitialState" format="enum">

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -10,6 +10,7 @@
         <attr name="umanoDragView" format="reference" />
         <attr name="umanoScrollableView" format="reference" />
         <attr name="umanoOverlay" format="boolean"/>
+        <attr name="umanoFlint" format="boolean"/>
         <attr name="umanoClipPanel" format="boolean"/>
         <attr name="umanoAnchorPoint" format="float" />
         <attr name="umanoInitialState" format="enum">


### PR DESCRIPTION
The idea is to have the same behaviour as any scrollable content inside the panel, so it behaves consistently when flinging the panel when still not fullscreen and when flinging the scrollable content inside it after fullscreen.