### PR TITLE
Fix typos and inconsistencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Android Sliding Up Panel
 =========================
 
-This library provides a simple way to add a draggable sliding up panel (popularized by Google Music and Google Maps) to your Android application.
+This library provides a simple way to add a draggable sliding-up panel (popularized by Google Music and Google Maps) to your Android application.
 
 As seen in Umano Android App (now acquired by Dropbox):
 
@@ -22,7 +22,7 @@ If you are using the library and you would like to have your app listed, simply 
 
 ### Importing the Library
 
-Simply add the following dependency to your `build.gradle` file to use the latest version:
+Add the following dependency to your `build.gradle` file to use the latest version:
 
 ```groovy
 dependencies {
@@ -37,9 +37,9 @@ dependencies {
 
 * Include `com.sothree.slidinguppanel.SlidingUpPanelLayout` as the root element in your activity layout.
 * The layout must have `gravity` set to either `top` or `bottom`.
-* Make sure that it has two children. The first child is your main layout. The second child is your layout for the sliding up panel.
+* Make sure that it has two children. The first child is your main layout. The second child is your layout for the sliding-up panel.
 * The main layout should have the width and the height set to `match_parent`.
-* The sliding layout should have the width set to `match_parent` and the height set to either `match_parent`, `wrap_content` or the max desireable height. If you would like to define the height as the percetange of the screen, set it to `match_parent` and also define a `layout_weight` attribute for the sliding view.
+* The sliding layout should have the width set to `match_parent` and the height set to either `match_parent`, `wrap_content` or the max desirable height. If you would like to define the height as the percentage of the screen, set it to `match_parent` and also define a `layout_weight` attribute for the sliding view.
 * By default, the whole panel will act as a drag region and will intercept clicks and drag events. You can restrict the drag area to a specific view by using the `setDragView` method or `umanoDragView` attribute.
 
 For more information, please refer to the sample code.
@@ -75,7 +75,7 @@ For smooth interaction with the ActionBar, make sure that `windowActionBarOverla
     <item name="android:windowActionBarOverlay">true</item>
 </style>
 ```
-However, in this case you would likely want to add a top margin to your main layout of `?android:attr/actionBarSize`
+However, in this case, you would likely want to add a top margin to your main layout of `?android:attr/actionBarSize`
 or `?attr/actionBarSize` to support older API versions.
 
 ### Caveats, Additional Features and Customization
@@ -84,20 +84,20 @@ or `?attr/actionBarSize` to support older API versions.
 * You can change the panel height by using the `setPanelHeight` method or `umanoPanelHeight` attribute.
 * If you would like to hide the shadow above the sliding panel, set `shadowHeight` attribute to 0.
 * Use `setEnabled(false)` to completely disable the sliding panel (including touch and programmatic sliding)
-* Use `setTouchEnabled(false)` to disables panel's touch responsiveness (drag and click), you can still control the panel programatically
+* Use `setTouchEnabled(false)` to disable the panel's touch responsiveness (drag and click). You can still control the panel programmatically
 * Use `getPanelState` to get the current panel state
 * Use `setPanelState` to set the current panel state
-* You can add parallax to the main view by setting `umanoParallaxOffset` attribute (see demo for the example).
-* You can set a anchor point in the middle of the screen using `setAnchorPoint` to allow an intermediate expanded state for the panel (similar to Google Maps).
+* You can add parallax to the main view by setting the `umanoParallaxOffset` attribute (see demo for the example).
+* You can set an anchor point in the middle of the screen using `setAnchorPoint` to allow an intermediate expanded state for the panel (similar to Google Maps).
 * You can set a `PanelSlideListener` to monitor events about sliding panes.
 * You can also make the panel slide from the top by changing the `layout_gravity` attribute of the layout to `top`.
-* You can provide a scroll interpolator for the panel movement by setting `umanoScrollInterpolator` attribute. For instance, if you want a bounce or overshoot effect for the panel.
-* By default, the panel pushes up the main content. You can make it overlay the main content by using `setOverlayed` method or `umanoOverlay` attribute. This is useful if you would like to make the sliding layout semi-transparent. You can also set `umanoClipPanel` to false to make the panel transparent in non-overlay mode.
+* You can provide a scroll interpolator for the panel movement by setting the `umanoScrollInterpolator` attribute. For instance, if you want a bounce or overshoot effect for the panel.
+* By default, the panel pushes up the main content. You can make it overlay the main content by using the `setOverlayed` method or `umanoOverlay` attribute. This is useful if you would like to make the sliding layout semi-transparent. You can also set `umanoClipPanel` to false to make the panel transparent in non-overlay mode.
 * By default, the main content is dimmed as the panel slides up. You can change the dim color by changing `umanoFadeColor`. Set it to `"@android:color/transparent"` to remove dimming completely.
 
 ### Scrollable Sliding Views
 
-If you have a scrollable view inside of the sliding panel, make sure to set `umanoScrollableView` attribute on the panel to supported nested scrolling. The panel supports `ListView`, `ScrollView` and `RecyclerView` out of the box, but you can add support for any type of a scrollable view by setting a custom `ScrollableViewHelper`. Here is an example for `NestedScrollView`
+If you have a scrollable view inside of the sliding panel, make sure to set the `umanoScrollableView` attribute on the panel to support nested scrolling. The panel supports `ListView`, `ScrollView` and `RecyclerView` out of the box, but you can add support for any type of scrollable view by setting a custom `ScrollableViewHelper`. Here is an example for `NestedScrollView`
 
 ```
 public class NestedScrollableViewHelper extends ScrollableViewHelper {
@@ -121,7 +121,7 @@ Once you define your helper, you can set it using `setScrollableViewHelper` on t
 
 ### Implementation
 
-This library was initially based on the opened-sourced [SlidingPaneLayout](http://developer.android.com/reference/android/support/v4/widget/SlidingPaneLayout.html) component from the r13 of the Android Support Library. Thanks Android team!
+This library was initially based on the opened-sourced [SlidingPaneLayout](http://developer.android.com/reference/android/support/v4/widget/SlidingPaneLayout.html) component from the r13 of the Android Support Library. Thanks, Android team!
 
 ### Requirements
 
@@ -146,30 +146,30 @@ If you have an awesome pull request, send it over!
   * Bug fixes
 * 3.3.1
   * Lots of bug fixes from various pull requests.
-  * Removed the nineoldandroids dependency. Use ViewCompat instead.
+  * Remove the nineoldandroids dependency. Use ViewCompat instead.
 * 3.3.0
   * You can now set a `FadeOnClickListener`, for when the faded area of the main content is clicked.
   * `PanelSlideListener` has a new format (multiple of them can be set now
-  * Fixed the setTouchEnabled bug
+  * Fix the setTouchEnabled bug
 * 3.2.1
   * Add support for `umanoScrollInterpolator`
   * Add support for percentage-based sliding panel height using `layout_weight` attribute
-  * Add `ScrollableViewHelper` to allow users extend support for new types of scrollable views.
+  * Add `ScrollableViewHelper` to allow users to extend support for new types of scrollable views.
 * 3.2.0
   * Rename `umanoParalaxOffset` to `umanoParallaxOffset`
   * RecyclerView support.
 * 3.1.0
-  * Added `umanoScrollableView` to supported nested scrolling in children (only ScrollView and ListView are supported for now)
+  * Add `umanoScrollableView` to supported nested scrolling in children (only ScrollView and ListView are supported for now)
 * 3.0.0
-  * Added `umano` prefix for all attributes
-  * Added `clipPanel` attribute for supporting transparent panels in non-overlay mode.
+  * Add `umano` prefix for all attributes
+  * Add `clipPanel` attribute for supporting transparent panels in non-overlay mode.
   * `setEnabled(false)` - now completely disables the sliding panel (touch and programmatic sliding)
-  * `setTouchEnabled(false)` - disables panel's touch responsiveness (drag and click), you can still control the panel programatically
+  * `setTouchEnabled(false)` - disables the panel's touch responsiveness (drag and click), you can still control the panel programmatically
   * `getPanelState` - is now the only method to get the current panel state
   * `setPanelState` - is now the only method to modify the panel state from code
 * 2.0.2 - Allow `wrap_content` for sliding view height attribute. Bug fixes. 
 * 2.0.1 - Bug fixes. 
-* 2.0.0 - Cleaned up various public method calls. Added animated `showPanel`/`hidePanel` methods. 
+* 2.0.0 - Clean up various public method calls. Add animated `showPanel`/`hidePanel` methods. 
 * 1.0.1 - Initial Release 
 
 ### Licence


### PR DESCRIPTION
- Fixed any typos and grammar mistakes I came across
- Reworded some sentences for clarity
- Changelog was not consistent with tense (used both past and present). I opted to make it all present, but it can be changed to use past.